### PR TITLE
Add patch to change the path of the etcd binary to /bin/etcd

### DIFF
--- a/controllers/generators/images.go
+++ b/controllers/generators/images.go
@@ -33,11 +33,11 @@ func getDefaultCertifiedImages(images string) (*ImageCatalog, error) {
 	return catalog, nil
 }
 
-func (i *ImageCatalog) inject(pd *aimlv1beta1.Pachyderm) {
-	pd.Spec.Console.Image = setImageOptions(pd.Spec.Console.Image, i.Console)
-	pd.Spec.Pachd.Image = setImageOptions(pd.Spec.Pachd.Image, i.Pachd)
-	pd.Spec.Worker.Image = setImageOptions(pd.Spec.Worker.Image, i.Worker)
-	pd.Spec.Etcd.Image = setImageOptions(pd.Spec.Etcd.Image, i.Etcd)
+func (c *ImageCatalog) inject(pd *aimlv1beta1.Pachyderm) {
+	pd.Spec.Console.Image = setImageOptions(pd.Spec.Console.Image, c.Console)
+	pd.Spec.Pachd.Image = setImageOptions(pd.Spec.Pachd.Image, c.Pachd)
+	pd.Spec.Worker.Image = setImageOptions(pd.Spec.Worker.Image, c.Worker)
+	pd.Spec.Etcd.Image = setImageOptions(pd.Spec.Etcd.Image, c.Etcd)
 }
 
 func setImageOptions(user, shipped *aimlv1beta1.ImageOverride) *aimlv1beta1.ImageOverride {

--- a/controllers/generators/manifests.go
+++ b/controllers/generators/manifests.go
@@ -179,6 +179,12 @@ func (c *PachydermCluster) EtcdStatefulSet() *appsv1.StatefulSet {
 	for i, container := range etcd.Spec.Template.Spec.Containers {
 		if container.Name == "etcd" {
 			etcd.Spec.Template.Spec.Containers[i].Image = catalog.etcdImage().Name()
+			// Patch:  to change the location of the etcd binary
+			for j, arg := range container.Args {
+				if arg == "/usr/local/bin/etcd" {
+					etcd.Spec.Template.Spec.Containers[i].Args[j] = "/bin/etcd"
+				}
+			}
 		}
 	}
 

--- a/controllers/generators/template.go
+++ b/controllers/generators/template.go
@@ -85,6 +85,8 @@ func loadPachydermTemplates(pd *aimlv1beta1.Pachyderm) (map[string]string, error
 	return releaseutil.SplitManifests(release.Manifest), nil
 }
 
+// ChartDirectory contains information on the helm charts
+// available to the the operator
 type ChartDirectory struct {
 	// Path to the chart values.yaml file
 	Values string


### PR DESCRIPTION
Add patch to change the path of the etcd binary from /usr/local/bin/etcd to /bin/etcd in the rhel7/etcd container image.

Changes:
* apply patch to override the path of the etcd binary.
* Refactor code and add comments

Signed-off-by: Edmund Ochieng <eochieng@redhat.com>