### PR TITLE
revert patch to use alternate etcd binary path

### DIFF
--- a/controllers/generators/manifests.go
+++ b/controllers/generators/manifests.go
@@ -179,12 +179,6 @@ func (c *PachydermCluster) EtcdStatefulSet() *appsv1.StatefulSet {
 	for i, container := range etcd.Spec.Template.Spec.Containers {
 		if container.Name == "etcd" {
 			etcd.Spec.Template.Spec.Containers[i].Image = catalog.etcdImage().Name()
-			// Patch:  to change the location of the etcd binary
-			for j, arg := range container.Args {
-				if arg == "/usr/local/bin/etcd" {
-					etcd.Spec.Template.Spec.Containers[i].Args[j] = "/bin/etcd"
-				}
-			}
 		}
 	}
 


### PR DESCRIPTION
Add change to revert the path of the etcd binary from `/bin/etcd`  back to the original value of `/usr/local/bin/etcd`.

Signed-off-by: Edmund Ochieng <ochienged@gmail.com>