### PR TITLE
fix worker and worker sidecar image name

### DIFF
--- a/controllers/generators/images.go
+++ b/controllers/generators/images.go
@@ -88,3 +88,7 @@ func (c *ImageCatalog) pachdImage() *aimlv1beta1.ImageOverride {
 func (c *ImageCatalog) utilsImage() *aimlv1beta1.ImageOverride {
 	return c.Utilities
 }
+
+func (c *ImageCatalog) workerImage() *aimlv1beta1.ImageOverride {
+	return c.Worker
+}

--- a/controllers/generators/manifests.go
+++ b/controllers/generators/manifests.go
@@ -356,6 +356,12 @@ func setupPachd(pd *aimlv1beta1.Pachyderm, pachd *appsv1.Deployment) {
 				if environment.Name == "POSTGRES_DATABASE" {
 					environment.Value = pd.Spec.Pachd.Postgres.Database
 				}
+				if environment.Name == "WORKER_IMAGE" {
+					environment.Value = catalog.workerImage().Name()
+				}
+				if environment.Name == "WORKER_SIDECAR_IMAGE" {
+					environment.Value = catalog.pachdImage().Name()
+				}
 				env = append(env, environment)
 			}
 			pachd.Spec.Template.Spec.Containers[i].Env = env


### PR DESCRIPTION
Fix format for the worker and worker sidecar container images when using image digest in lieu of tags.

Signed-off-by: Edmund Ochieng <ochienged@gmail.com>