### PR TITLE
add functionality to enable licensing for pachyderm enterprise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,8 @@ bundle-push:
 	${BUILD_TOOL} push $(BUNDLE_IMG)
 
 index-build:
-	bash -x ./hack/scripts/build_index_image.sh
+	#bash -x ./hack/scripts/build_index_image.sh
+	opm index add --bundles $(BUNDLE_IMG) --tag quay.io/opdev/pachyderm-index:latest --pull-tool podman
 	
 index-push: index-build
 	${BUILD_TOOL} push quay.io/opdev/pachyderm-index:latest

--- a/api/v1beta1/pachyderm_types.go
+++ b/api/v1beta1/pachyderm_types.go
@@ -51,6 +51,12 @@ type PachydermSpec struct {
 	Postgres PostgresOptions `json:"postgresql,omitempty"`
 	// Allow user to provide an image pull secret
 	ImagePullSecret *string `json:"imagePullSecret,omitempty"`
+	// License for pachyderm enterprise.
+	// Takes the name of the secret containing the 'license' string
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enterprise License Secret",xDescriptors={"urn:alm:descriptor:io.kubernetes:Secret"}
+	License string `json:"license,omitempty"`
+	// The enterprise license string
+	EnterpriseLicense string `json:"-"`
 }
 
 // WorkerOptions allows the user to configure workers

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=pachyderm-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.14.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.17.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/aiml.pachyderm.com_pachyderms.yaml
+++ b/bundle/manifests/aiml.pachyderm.com_pachyderms.yaml
@@ -187,6 +187,10 @@ spec:
               imagePullSecret:
                 description: Allow user to provide an image pull secret
                 type: string
+              license:
+                description: License for pachyderm enterprise. Takes the name of the
+                  secret containing the 'license' string
+                type: string
               pachd:
                 description: Allows the user to customize the pachd instance(s)
                 properties:

--- a/bundle/manifests/pachyderm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pachyderm-operator.clusterserviceversion.yaml
@@ -48,11 +48,11 @@ metadata:
     description: Pachyderm provides the data layer that allows data science teams
       to productionize and scale their machine learning lifecycle with data driven
       automation, petabyte scalability and end-to-end reproducibility.
-    operators.operatorframework.io/builder: operator-sdk-v1.14.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.17.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/pachyderm/openshift-operator
     support: Pachyderm, Inc.
-  name: pachyderm-operator.v0.0.9
+  name: pachyderm-operator.v0.1.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -169,6 +169,12 @@ spec:
         path: etcd.storageSize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: License for pachyderm enterprise. Takes the name of the secret
+          containing the 'license' string
+        displayName: Enterprise License Secret
+        path: license
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
       - description: Set an ID for the cluster deployment. Defaults to a random value
           if none is provided
         displayName: Cluster ID
@@ -895,7 +901,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: registry.connect.redhat.com/pachyderm/pachyderm-operator@sha256:ee43b56a7f79fdaec2048a963825b924f4e990e54901773b08716354f1d92bc5
+                image: quay.io/opdev/pachyderm-operator:latest
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -978,7 +984,7 @@ spec:
   provider:
     name: Pachyderm, Inc.
     url: https://pachyderm.com
-  version: 0.0.9
+  version: 0.1.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: pachyderm-operator
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.14.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.17.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 
@@ -15,4 +15,4 @@ annotations:
   operators.operatorframework.io.test.config.v1: tests/scorecard/
 
   # OpenShift annotations.
-  com.redhat.openshift.versions: v4.6-v4.9
+  com.redhat.openshift.versions: v4.6

--- a/config/crd/bases/aiml.pachyderm.com_pachyderms.yaml
+++ b/config/crd/bases/aiml.pachyderm.com_pachyderms.yaml
@@ -189,6 +189,10 @@ spec:
               imagePullSecret:
                 description: Allow user to provide an image pull secret
                 type: string
+              license:
+                description: License for pachyderm enterprise. Takes the name of the
+                  secret containing the 'license' string
+                type: string
               pachd:
                 description: Allows the user to customize the pachd instance(s)
                 properties:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -11,6 +11,6 @@ configMapGenerator:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- digest: sha256:ee43b56a7f79fdaec2048a963825b924f4e990e54901773b08716354f1d92bc5
-  name: controller
-  newName: registry.connect.redhat.com/pachyderm/pachyderm-operator
+- name: controller
+  newName: quay.io/opdev/pachyderm-operator
+  newTag: latest

--- a/config/manifests/bases/pachyderm-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pachyderm-operator.clusterserviceversion.yaml
@@ -130,6 +130,12 @@ spec:
         path: etcd.storageSize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: License for pachyderm enterprise. Takes the name of the secret
+          containing the 'license' string
+        displayName: Enterprise License Secret
+        path: license
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
       - description: Set an ID for the cluster deployment. Defaults to a random value
           if none is provided
         displayName: Cluster ID

--- a/hack/bundle_prep.sh
+++ b/hack/bundle_prep.sh
@@ -46,7 +46,7 @@ openshift_annotations() {
 cat <<EOF>> ${OPERATOR_ANNOTATIONS_FILE}
 
   # OpenShift annotations.
-  com.redhat.openshift.versions: v4.6-v4.9
+  com.redhat.openshift.versions: v4.6
 EOF
 }
 

--- a/hack/charts/v2.0.5/values.yaml
+++ b/hack/charts/v2.0.5/values.yaml
@@ -238,7 +238,7 @@ pachd:
     #apiGrpcPort:
     #  expose: true
     #  port: 30650
-  enterpriseLicenseKey: ""
+  enterpriseLicenseKey: "{{ .Spec.EnterpriseLicense }}"
   rootToken: ""
   enterpriseSecret: ""
   oauthClientSecret: ""


### PR DESCRIPTION
This update provides a way to provide a pachyderm enterprise licensing when deploying a Pachyderm resource.

In addition, we change the supported Openshift versions from `v4.6-v4.9` to `v4.6` to allow the operator to run on future Openshift clusters such as the upcoming v4.10.

Signed-off-by: Edmund Ochieng <ochienged@gmail.com>