### PR TITLE
scale down pachd deployment when pause annotation is set

### DIFF
--- a/api/v1beta1/pachyderm_webhook.go
+++ b/api/v1beta1/pachyderm_webhook.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
 
 	"sort"
 
@@ -31,10 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"golang.org/x/mod/semver"
-)
-
-const (
-	maintenanceMode = "pachyderm.com/maintenance"
 )
 
 // log is for logging in this package.
@@ -160,30 +157,11 @@ func (r *Pachyderm) DeployPostgres() bool {
 	return !r.Spec.Postgres.Disable
 }
 
-// MaintenanceMode method add maintenance annotation
-// on the pachyderm resource
-// Returns true if changed
-func (r *Pachyderm) MaintenanceMode() bool {
-	if len(r.Annotations) == 0 {
-		r.Annotations = map[string]string{}
+func (r *Pachyderm) IsPaused() bool {
+	v := r.Annotations["pachyderm.com/pause-cluster"]
+	pause, err := strconv.ParseBool(v)
+	if err != nil {
+		return false
 	}
-
-	_, ok := r.Annotations[maintenanceMode]
-	if !ok {
-		r.Annotations[maintenanceMode] = "true"
-		return true
-	}
-	return false
-}
-
-// NormalMode method removes maintenance annotation
-// from the pachyderm resource
-func (r *Pachyderm) NormalMode() bool {
-	if len(r.Annotations) > 0 {
-		if _, ok := r.Annotations[maintenanceMode]; ok {
-			delete(r.Annotations, maintenanceMode)
-			return true
-		}
-	}
-	return false
+	return pause
 }

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=pachyderm-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.17.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.18.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/pachyderm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pachyderm-operator.clusterserviceversion.yaml
@@ -48,7 +48,7 @@ metadata:
     description: Pachyderm provides the data layer that allows data science teams
       to productionize and scale their machine learning lifecycle with data driven
       automation, petabyte scalability and end-to-end reproducibility.
-    operators.operatorframework.io/builder: operator-sdk-v1.17.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.18.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/pachyderm/openshift-operator
     support: Pachyderm, Inc.

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: pachyderm-operator
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.17.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.18.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 


### PR DESCRIPTION
When the "operator.pachyderm.com/pause-cluster" is set to "true", add
pod count annotation to the pachd deployment and scale down the number
of pods to zero.

Signed-off-by: Edmund Ochieng <ochienged@gmail.com>