### PR TITLE
scale up pachd once the pause annotation is removed

### DIFF
--- a/api/v1beta1/pachyderm_types.go
+++ b/api/v1beta1/pachyderm_types.go
@@ -32,6 +32,10 @@ const (
 	GoogleStorageBackend string = "GOOGLE"
 	// Minio storage backend for pachd
 	MinioStorageBackend string = "MINIO"
+	// Pachyderm Pause Annotation
+	PachydermPauseAnnotation string = "operator.pachyderm.com/pause-cluster"
+	// Pachd Pod Count Annotation
+	PachdPodCountAnnotation string = "operator.pachyderm.com/pachd-podcount"
 )
 
 // PachydermSpec defines the desired state of Pachyderm

--- a/api/v1beta1/pachyderm_webhook.go
+++ b/api/v1beta1/pachyderm_webhook.go
@@ -158,8 +158,12 @@ func (r *Pachyderm) DeployPostgres() bool {
 }
 
 func (r *Pachyderm) IsPaused() bool {
-	v := r.Annotations["pachyderm.com/pause-cluster"]
-	pause, err := strconv.ParseBool(v)
+	pauseState, ok := r.Annotations[PachydermPauseAnnotation]
+	if !ok {
+		return false
+	}
+
+	pause, err := strconv.ParseBool(pauseState)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
This commit scales up pachd pods to original number of replicas once the
"operator.pachyderm.com/pause-cluster" is either removed or set to false
on the pachyderm object.

Signed-off-by: Edmund Ochieng <ochienged@gmail.com>