### PR TITLE
create pachyderm object from backup (part 2)

### DIFF
--- a/controllers/pachydermexport_controller.go
+++ b/controllers/pachydermexport_controller.go
@@ -90,7 +90,10 @@ func (r *PachydermExportReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, goerrors.New("storage secret name required")
 		}
 		if err := r.restorePachyderm(ctx, export); err != nil {
-			return ctrl.Result{}, err
+			if err != ErrPostgresNotReady {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
 		}
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
Restore a pachyderm object from backup. The pull request also places the pachyderm into maintenance mode to restore the database before returning it into normal state.

Signed-off-by: Edmund Ochieng <ochienged@gmail.com>