### PR TITLE
remove the maintenance annotation after backup

### DIFF
--- a/bundle/manifests/pachyderm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pachyderm-operator.clusterserviceversion.yaml
@@ -43,7 +43,7 @@ metadata:
     capabilities: Basic Install
     categories: AI/Machine Learning
     certified: "true"
-    containerImage: registry.connect.redhat.com/pachyderm/pachyderm-operator@sha256:b3ec850de86c044a070330154975e3a392cd0e711f6d50213ec198e4f3350191
+    containerImage: quay.io/opdev/pachyderm-operator:latest
     createdAt: "2021-05-20T08:05:00Z"
     description: Pachyderm provides the data layer that allows data science teams
       to productionize and scale their machine learning lifecycle with data driven
@@ -52,7 +52,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/pachyderm/openshift-operator
     support: Pachyderm, Inc.
-  name: pachyderm-operator.v0.1.2
+  name: pachyderm-operator.v0.1.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -930,7 +930,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: registry.connect.redhat.com/pachyderm/pachyderm-operator@sha256:b3ec850de86c044a070330154975e3a392cd0e711f6d50213ec198e4f3350191
+                image: quay.io/opdev/pachyderm-operator:latest
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -1022,7 +1022,7 @@ spec:
   provider:
     name: Pachyderm, Inc.
     url: https://pachyderm.com
-  version: 0.1.2
+  version: 0.1.3
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -14,6 +14,6 @@ configMapGenerator:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- digest: sha256:b3ec850de86c044a070330154975e3a392cd0e711f6d50213ec198e4f3350191
-  name: controller
-  newName: registry.connect.redhat.com/pachyderm/pachyderm-operator
+- name: controller
+  newName: quay.io/opdev/pachyderm-operator
+  newTag: latest


### PR DESCRIPTION
Remove the pachyderm pause annotation from the .metadata.annotations
once the backup task is completed

Signed-off-by: Edmund Ochieng <ochienged@gmail.com>